### PR TITLE
docs: switch GeoIcons url to gh repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1750,7 +1750,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [animated-icons](https://github.com/ajitzero/animated-icons) - Animated icons for Angular based on [moving icons](https://www.movingicons.dev/).
 * [@hugeicons/angular](https://github.com/hugeicons/hugeicons/tree/main/packages/angular) - 5,400+ free MIT-licensed stroke-rounded icons for Angular.
 * [@quikturn-sdk/logos-angular](https://github.com/quikturn-sdk/Company-Logos) - TypeScript SDK for the [Quikturn Logos API](https://getquikturn.io/) - Fetch any company's logo by domain name.
-* [GeoIcons](https://geoicons.io) - Geographic map icons for every country, territory, and world region as tree-shakable Angular standalone components.
+* [GeoIcons](https://github.com/getgeoicons/geoicons) - Geographic map icons for every country, territory, and world region as tree-shakable Angular standalone components.
 * [ngx-iconify-stack](https://github.com/WanderleeDev/ngx-iconify-stack) - A lightweight, SSR-safe Angular wrapper for [Iconify](https://iconify.design/).
 * [vadivam](https://github.com/praveenjuge/vadivam) - Pixel-perfect 24px outline icons for SVG, React, React Native, Vue, Svelte, Solid, Angular, Astro, and Preact.
 * [ycon.cc](https://ycon.cc) - Search 300,000+ Iconify icons and copy ready-to-use code for React, Vue, Symfony, Next.js, Astro, Svelte, Angular, Laravel and more.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the GeoIcons link in the icon directory to point to its GitHub repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->