### PR TITLE
Add ngx-json-render to the AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,6 +668,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [ngx-ai-devtools](https://github.com/ahmedkhan1/ngx-ai-devtools) -  See every prompt, response, token, and dollar your app spends without leaving the browser tab.
 * [ngx-bob](https://github.com/scottstraughan/ngx-bob) - Angular chat widget with messaging, local history, error handling, commands, and search.
 * [ngx-gen-ui](https://github.com/alessiopelliccione/ngx-gen-ui) - Lightweight Angular directive and service for streaming generative UI content via Firebase AI.
+* [ngx-json-render](https://github.com/shteynu/ngx-json-render) - Angular renderer for Vercel's json-render — an LLM streams a JSON spec constrained to your component catalog, rendered progressively as real Angular components with signals.
 * [ngx-prompt-kit](https://github.com/PianoNic/ngx-prompt-kit) - Angular components for AI chat interfaces, built on Spartan UI.
 * [ngx-quill-ink](https://github.com/AhsanAyaz/ngx-quill-ink) - TypeScript engine and Angular wrapper animating text streams as handwriting and capturing pen strokes for Vision LLMs.
 * [ngx-testbox-agent-skill](https://github.com/kirill-kolomin/ngx-testbox-agent-skill) - AI Agent skill for the `ngx-testbox` testing package.


### PR DESCRIPTION
Adds [ngx-json-render](https://github.com/shteynu/ngx-json-render) to **Development Utilities → AI** (alphabetical order, between `ngx-gen-ui` and `ngx-prompt-kit`).

It's an Angular renderer for Vercel Labs' [json-render](https://github.com/vercel-labs/json-render) generative-UI format: an LLM streams a JSON spec constrained to a typed component catalog, and the spec renders progressively as real Angular components — signals-based, zoneless-friendly, Angular ≥ 21. Apache-2.0, [on npm](https://www.npmjs.com/package/ngx-json-render), with a [live demo](https://shteynu.github.io/ngx-json-render/).

Disclosure: I'm the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `ngx-json-render` to the AI section of the Awesome Angular list.
  * Described its support for streaming constrained JSON specifications and progressively rendering them as Angular components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->