### PR TITLE
docs: add ngx-exitus-tiptap-editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1582,6 +1582,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [ngx-image-editor](https://github.com/eliranbar/ngx-edit-images) - A professional image editor with a free forever tier and offline Ed25519-licensed premium tools.
 * [Scryb](https://scryb.dev/) - A $39/month flat-rate TypeScript WYSIWYG editor built on Tiptap that offers unlimited loads, end users, and documents.
 * [nge-ide](https://github.com/cisstech/nge-ide) - Via a single `<ide-root />` component, NGE IDE embeds a full desktop editor shell into Angular apps.
+* [ngx-exitus-tiptap-editor](https://github.com/marcelinombb/ngx-exitus-tiptap-editor) - A powerful, feature-rich Tiptap-based Rich Text Editor for Angular 18+, specifically designed for educational and technical content.
 
 ### File Upload
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `ngx-exitus-tiptap-editor` to the Awesome Angular Editors list.
  * Included a link to the Tiptap-based rich text editor library for Angular 18 and later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->