### PR TITLE
docs: add sdcorejs-angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -2179,6 +2179,7 @@ for the creation of web applications developed with Angular.
 * [angular-material-extended](https://github.com/reisi007/angular-material-extended) - Community extensions for Angular Material (Standalone, Signals, Zoneless, SSR, M3 Theming).
 * [mat-exp](https://github.com/Angular-Material-Dev/mat-exp) - A library of components and styles for Angular Material, built on the latest Material Design 3 Expressive Design System.
 * [angular-material-components](https://github.com/fbf-prog64/angular-material-components) - Provides extra components for Angular Material projects: Datetime picker, Time picker, Color picker, etc.
+* [sdcorejs-angular](https://github.com/sdcorejs/sdcorejs-angular) - Reusable Angular UI for data-heavy business applications.
 
 ### UI Libraries built on Tailwind CSS
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added `sdcorejs-angular` to the list of UI libraries built on Material in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->