### PR TITLE
docs: add form-nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1567,6 +1567,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [GolemUI](https://github.com/golemui/golemui) - Declarative Form Engine.
 * [formular.dev](https://github.com/binaryjack/formular.dev) - An advanced, high-performance, schema-first form management and validation engine for modern TypeScript and JavaScript applications.
 * [formisch](https://github.com/open-circle/formisch) - A schema-based, headless JS form library that delivers fast, type-safe state management and validation within a lightweight, modular bundle.
+* [form-nodes](https://github.com/gastonmesseri/form-nodes) - Typed Signal-based forms for Angular.
 
 ### Form Controls
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added `form-nodes` to the Forms section of the README.
  - Described it as a library for typed, signal-based forms in Angular.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->