### PR TITLE
docs: add mochart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1307,6 +1307,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [Foblex Flow](https://github.com/Foblex/f-flow) - Angular-native library for node editors, workflow builders and interactive diagrams: drag-and-drop nodes and connections, minimap, auto-layout, virtualization, and a keyboard accessibility layer.
 * [highcharts-angular](https://github.com/highcharts/highcharts-angular) - Official minimal [Highcharts](https://www.highcharts.com/) integration for Angular.
 * [michi-vz-mono](https://github.com/beany-vu/michi-vz-mono) - One engine powering 17 interactive, accessible chart types with seamless support for Angular and more, all emitting LLM‑ready data for reports, dashboards, and AI features.
+* [mochart-angular](https://github.com/mocharts/mochart/blob/main/packages/mochart-angular/README.md) - Angular components for the [@mochart/core](https://github.com/mocharts/mochart) charting library.
 * [ng-apexcharts](https://github.com/apexcharts/ng-apexcharts) - Angular wrapper for ApexCharts to build interactive visualizations.
 * [ng-chartist](https://github.com/willsoto/ng-chartist) - Angular component for [Chartist.js](https://github.com/chartist-js/chartist).
 * [ng-charts](https://github.com/AleksanderBodurri/ng-charts) - Reangular port of `recharts`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added `mochart-angular` to the Charts section of the README as an Angular component library for the `@mochart/core` charting library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->