### PR TITLE
docs: add ng-signal-state-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1063,6 +1063,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [ng-craft](https://github.com/ng-angular-stack/ng-craft) - A Signal-based Angular toolkit for modeling state, asynchronous work, services, forms, dependency injection, and routes with explicit dependencies and strong TypeScript inference.
 * [object-recipes](https://github.com/royhansen99/object-recipes) - Lightweight, type-safe Immer alternative using string paths for immutable nested updates, featuring deep-equal optimization and universal state management integration.
 * [rheo](https://github.com/japuentem/rheo-framework) - Ultra-fast reactive state, SWR in-memory caching, request deduplication & optimistic data-flow micro-framework.
+* [ng-signal-state-manager](https://github.com/EugBoy/ng-signal-state-manager) - Standalone, lightweight, and type-safe async query cache and state manager for Angular powered by Angular Signals and RxJS.
 
 ## Testing
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added `ng-signal-state-manager` to the README’s list of other state libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->