### PR TITLE
docs: add web-fragments-migration-demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [ng-dynamic-mf](https://github.com/LoaderB0T/ng-dynamic-mf) - Truly dynamic modules at runtime with Module Federation.
 * [ngx-mfe](https://github.com/dkhrunov/ngx-mfe) - Angular library for working with micro-frontends in Webpack 5 and the Module Federation plugin.
 * [webpack-module-federation-with-angular](https://github.com/edumserrano/webpack-module-federation-with-angular) - Guide to learn about Webpack Module Federation with several Angular code demos.
+* [web-fragments-migration-demo](https://github.com/anfibiacreativa/web-fragments-migration-demo) - Migration path from Angular monolithic SPA app, to micro-frontends featuring Qwik, Analog and Angular SSR.
 
 ### Monorepos
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added `web-fragments-migration-demo` to the Module Federation Webpack examples, highlighting a migration path from an Angular monolith to micro-frontends using Qwik, Analog, and Angular SSR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->