### PR TITLE
docs: add use-component-store

### DIFF
--- a/README.md
+++ b/README.md
@@ -2460,6 +2460,7 @@ for the creation of web applications developed with Angular.
 * [Signals](https://github.com/dmytrodemchenko/Signals) - Zero‑dependency, glitch‑free reactive signals for TypeScript and JavaScript using an optimized Angular‑inspired push/pull architecture.
 * [sio](https://github.com/silicia-apps/sio) - Silicia Framework: a fresh approach built upon Ionic, designed to streamline the development of hybrid applications and websites.
 * [UnReact.js](https://github.com/arnvjshi/unreactpjs) - A modern framework combining the best of Angular and React for enhanced component communication.
+* [use-component-store](https://github.com/jalbr74/use-component-store) - Provides a bare minimum implementation of a component store for React using RxJS.
 * [use-vue-service](https://github.com/kaokei/use-vue-service) - Lightweight Vue 3 state management with dependency injection, inspired by Angular services.
 * [weave](https://github.com/weave-framework/weave) - A fine-grained reactive, signal-native UI framework.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added `use-component-store` to the list of Angular-inspired solutions in the README.
  - Described it as a minimal RxJS-based component store implementation for React.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->