### PR TITLE
docs: add ngx-pdf-export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1920,6 +1920,7 @@ Current Angular version: [![npm version](https://badge.fury.io/js/%40angular%2Fc
 * [ng2-pdfjs-viewer](https://github.com/intbot/ng2-pdfjs-viewer) - An Angular component for PDFJS and ViewerJS (Supports all versions of Angular).
 * [ngx-document-signer](https://github.com/YaseenAlMufti/ngx-document-signer) - A reusable package that provides a PDF form creator and PDF signer.
 * [ngx-extended-pdf-viewer](https://github.com/stephanrauh/ngx-extended-pdf-viewer) - A full-blown PDF viewer for Angular 16+.
+* [ngx-pdf-export](https://github.com/mdabdulshahed/angular-pdf) - This DOM-aware, client-side Angular library converts rendered HTML elements directly in the browser into functional PDFs with fully selectable, searchable, and copyable text.
 * [ngx-pdf-viewer](https://github.com/subedigaurav/ngx-pdf-viewer) - A lightweight PDF viewer library for Angular applications.
 * [pdf-viewer-kit](https://github.com/AmanKrr/pdf-viewer-kit) - A modern, high-performance, framework-agnostic, lightweight PDF viewer and annotation library built on top of `pdf.js`.
 * [rm-ng-pdf-export](https://github.com/malikrajat/rm-ng-pdf-export) - Angular library for generating and exporting ultra-high-quality PDFs from HTML content with smart page breaking and crystal-clear rendering.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added `ngx-pdf-export` to the PDF resources list, including a link and details about converting rendered HTML into searchable, selectable, and copyable PDFs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->